### PR TITLE
P1 308 implementare notificaion sul server socket

### DIFF
--- a/websocket-server/src/app.module.ts
+++ b/websocket-server/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { GatewayModule } from './gateway/gateway.module';
+import { NotificationModule } from './notification/notification.module';
 
 @Module({
-  imports: [GatewayModule],
+  imports: [GatewayModule, NotificationModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/websocket-server/src/gateway/gateway.ts
+++ b/websocket-server/src/gateway/gateway.ts
@@ -12,10 +12,10 @@ export class MyGateway implements OnModuleInit {
     this.server.on('connection', async (socket) => {
       if(socket.handshake.query.id_prenotazione) {
         socket.join(socket.handshake.query.id_prenotazione);
-        console.log(socket.id + " connected to room: " + socket.handshake.query.id_prenotazione);
+        console.log(socket.id + " connected to gatewayOrdinazioneCollaborativa/room: " + socket.handshake.query.id_prenotazione);
       }
       socket.on('disconnect', () => {
-        console.log(socket.id + " disconnected from room: " + socket.handshake.query.id_prenotazione);
+        console.log(socket.id + " disconnected from gatewayOrdinazioneCollaborativa/room: " + socket.handshake.query.id_prenotazione);
       });
     });
   }

--- a/websocket-server/src/notification/dto/notification.dto.ts
+++ b/websocket-server/src/notification/dto/notification.dto.ts
@@ -1,0 +1,5 @@
+export class NotificationDto {
+  message: string;
+  title: string;
+  id_receiver: number[];
+}

--- a/websocket-server/src/notification/notification.controller.spec.ts
+++ b/websocket-server/src/notification/notification.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationController } from './notification.controller';
+
+describe('NotificationController', () => {
+  let controller: NotificationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationController],
+    }).compile();
+
+    controller = module.get<NotificationController>(NotificationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/websocket-server/src/notification/notification.controller.spec.ts
+++ b/websocket-server/src/notification/notification.controller.spec.ts
@@ -1,18 +1,43 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotificationController } from './notification.controller';
+import { NotificationGateway } from './notificationGateway';
+import { NotificationDto } from './dto/notification.dto';
 
 describe('NotificationController', () => {
   let controller: NotificationController;
+  let gateway: NotificationGateway;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [NotificationController],
+      providers: [
+        {
+          provide: NotificationGateway,
+          useValue: {
+            emitAll: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<NotificationController>(NotificationController);
+    gateway = module.get<NotificationGateway>(NotificationGateway);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  it('should call emitAll with the notification body', async () => {
+    const notification: NotificationDto = {
+      id_receiver: [1, 2, 3],
+      title: 'Test Title',
+      message: 'Test Message',
+    };
+
+    await controller.getNotification(notification);
+
+    expect(gateway.emitAll).toHaveBeenCalledWith(notification);
+  });
 });
+

--- a/websocket-server/src/notification/notification.controller.ts
+++ b/websocket-server/src/notification/notification.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { NotificationGateway } from './notificationGateway';
+
+@Controller('notification')
+export class NotificationController {
+
+    constructor(private notificationGateway: NotificationGateway) {}
+
+    @Post('send')
+    getNotification(@Body() body: any): string {
+        // do some shit.
+        this.notificationGateway.emitAll();
+        return "this controller received" + body;
+    }
+}

--- a/websocket-server/src/notification/notification.controller.ts
+++ b/websocket-server/src/notification/notification.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { NotificationGateway } from './notificationGateway';
+import { NotificationDto } from './dto/notification.dto';
 
 @Controller('notification')
 export class NotificationController {
@@ -7,9 +8,7 @@ export class NotificationController {
     constructor(private notificationGateway: NotificationGateway) {}
 
     @Post('send')
-    getNotification(@Body() body: any): string {
-        // do some shit.
-        this.notificationGateway.emitAll();
-        return "this controller received" + body;
+    async getNotification(@Body() body: NotificationDto)  {
+        await this.notificationGateway.emitAll(body);
     }
 }

--- a/websocket-server/src/notification/notification.module.ts
+++ b/websocket-server/src/notification/notification.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { NotificationController } from './notification.controller';
+import { NotificationGateway } from './notificationGateway';
+
+@Module({
+  controllers: [NotificationController],
+  providers: [NotificationGateway],
+})
+export class NotificationModule {}

--- a/websocket-server/src/notification/notificationGateway.spec.ts
+++ b/websocket-server/src/notification/notificationGateway.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationGateway,  } from './notificationGateway';
+import { NotificationDto } from './dto/notification.dto'
+import { Server } from 'socket.io';
+
+describe('NotificationGateway', () => {
+  let gateway: NotificationGateway;
+  let server: Server;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NotificationGateway],
+    }).compile();
+
+    gateway = module.get<NotificationGateway>(NotificationGateway);
+    server = new Server();
+    gateway.server = server;
+  });
+
+  it('should emit notifications to all receivers', async () => {
+    const emitSpy = jest.spyOn(server, 'to').mockReturnThis();
+    const emitToSpy = jest.spyOn(server, 'emit');
+
+    const notification: NotificationDto = {
+      id_receiver: [1, 2, 3],
+      title: 'Test Title',
+      message: 'Test Message',
+    };
+
+    await gateway.emitAll(notification);
+
+    expect(emitSpy).toHaveBeenCalledTimes(3);
+    expect(emitSpy).toHaveBeenCalledWith('1');
+    expect(emitSpy).toHaveBeenCalledWith('2');
+    expect(emitSpy).toHaveBeenCalledWith('3');
+
+    expect(emitToSpy).toHaveBeenCalledTimes(3);
+    expect(emitToSpy).toHaveBeenCalledWith('onNotification', JSON.stringify({ title: notification.title, message: notification.message }));
+  });
+});

--- a/websocket-server/src/notification/notificationGateway.spec.ts
+++ b/websocket-server/src/notification/notificationGateway.spec.ts
@@ -29,12 +29,10 @@ describe('NotificationGateway', () => {
 
     await gateway.emitAll(notification);
 
-    expect(emitSpy).toHaveBeenCalledTimes(3);
-    expect(emitSpy).toHaveBeenCalledWith('1');
-    expect(emitSpy).toHaveBeenCalledWith('2');
-    expect(emitSpy).toHaveBeenCalledWith('3');
+    expect(emitSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(['1', '2', '3']);
 
-    expect(emitToSpy).toHaveBeenCalledTimes(3);
+    expect(emitToSpy).toHaveBeenCalled();
     expect(emitToSpy).toHaveBeenCalledWith('onNotification', JSON.stringify({ title: notification.title, message: notification.message }));
   });
 });

--- a/websocket-server/src/notification/notificationGateway.ts
+++ b/websocket-server/src/notification/notificationGateway.ts
@@ -32,9 +32,8 @@ export class NotificationGateway implements OnModuleInit {
 
   @SubscribeMessage('onNotification')
   async emitAll(notification: NotificationDto) {
-    notification.id_receiver.forEach((id) => {
-       this.server.to(id.toString()).emit('onNotification', JSON.stringify({title: notification.title, message : notification.message}));
-    });
+    const ids = notification.id_receiver.map((id) => id.toString());
+    this.server.to(ids).emit('onNotification', JSON.stringify({title: notification.title, message : notification.message}));
     console.log("sending notification to " + notification.id_receiver);
   }
 

--- a/websocket-server/src/notification/notificationGateway.ts
+++ b/websocket-server/src/notification/notificationGateway.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-@WebSocketGateway({ cors: { origin: '*' } })
+@WebSocketGateway(81, { cors: { origin: '*' } })
 @Injectable()
 export class NotificationGateway implements OnModuleInit {
   // riferimento al server socket che sta girando.
@@ -11,19 +11,19 @@ export class NotificationGateway implements OnModuleInit {
 
   onModuleInit() {
     this.server.on('connection', async (socket) => {
-      if (socket.handshake.query.id_prenotazione) {
-        socket.join(socket.handshake.query.id_prenotazione);
+      if (socket.handshake.query.id_utente) {
+        socket.join(socket.handshake.query.id_utente);
         console.log(
           socket.id +
-            ' connected to room: ' +
-            socket.handshake.query.id_prenotazione,
+            ' connected to notifcationGateway/room: ' +
+            socket.handshake.query.id_utente,
         );
       }
       socket.on('disconnect', () => {
         console.log(
           socket.id +
-            ' disconnected from room: ' +
-            socket.handshake.query.id_prenotazione,
+            ' disconnected from notifcationGateway/room: ' +
+            socket.handshake.query.id_utente,
         );
       });
     });

--- a/websocket-server/src/notification/notificationGateway.ts
+++ b/websocket-server/src/notification/notificationGateway.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-@WebSocketGateway(81, { cors: { origin: '*' } })
+@WebSocketGateway({ cors: { origin: '*' }, namespace : "notification"  })
 @Injectable()
 export class NotificationGateway implements OnModuleInit {
   // riferimento al server socket che sta girando.
@@ -11,19 +11,19 @@ export class NotificationGateway implements OnModuleInit {
 
   onModuleInit() {
     this.server.on('connection', async (socket) => {
-      if (socket.handshake.query.id_utente) {
-        socket.join(socket.handshake.query.id_utente);
+      if (socket.handshake.query.id_prenotazione) {
+        socket.join(socket.handshake.query.id_prenotazione);
         console.log(
           socket.id +
             ' connected to notifcationGateway/room: ' +
-            socket.handshake.query.id_utente,
+            socket.handshake.query.id_prenotazione,
         );
       }
       socket.on('disconnect', () => {
         console.log(
           socket.id +
             ' disconnected from notifcationGateway/room: ' +
-            socket.handshake.query.id_utente,
+            socket.handshake.query.id_prenotazione,
         );
       });
     });

--- a/websocket-server/src/notification/notificationGateway.ts
+++ b/websocket-server/src/notification/notificationGateway.ts
@@ -1,0 +1,35 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+@WebSocketGateway({ cors: { origin: '*' } })
+@Injectable()
+export class NotificationGateway implements OnModuleInit {
+  // riferimento al server socket che sta girando.
+  @WebSocketServer()
+  server: Server;
+
+  onModuleInit() {
+    this.server.on('connection', async (socket) => {
+      if (socket.handshake.query.id_prenotazione) {
+        socket.join(socket.handshake.query.id_prenotazione);
+        console.log(
+          socket.id +
+            ' connected to room: ' +
+            socket.handshake.query.id_prenotazione,
+        );
+      }
+      socket.on('disconnect', () => {
+        console.log(
+          socket.id +
+            ' disconnected from room: ' +
+            socket.handshake.query.id_prenotazione,
+        );
+      });
+    });
+  }
+
+  emitAll(): void {
+    console.log("going to emit evento to all clients that are subscribed to this thing");
+  }
+}


### PR DESCRIPTION
Aggiunta la logica della parte webSocket per far funzionare il sistema di notifiche all'interno dell'applicazione.
Scritti i test di unità per notification.controller.ts e notificationGateway.ts.

ATTENZIONE: il tipo NotificationDTO all'interno della parte web socket contiene una proprietà chiamata id_receiver, di tipo number[] (nel back-end al momento della creazione di questa PR è di tipo number).

Questo viene fatto in quanto, se si vogliono notificare più utenti collegati al socket server, si deve avere un array di id_receiver.

Quando verrà fatta l'integrazione con il back-end, si deve sistemare NotificationDTO e renderlo conforme al tipo di dato presente all'interno del NotificationGateway.
Per quanto riguarda le chiamate front-end per la connessione al NotificationGateway, l'url deve essere il seguente:

localhost:8000/notification?id_utente=number.

